### PR TITLE
fix: move .rtp2_cache to temp dir

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,5 +22,5 @@ export default {
       dest: './build/index.es.js'
     }
   ],
-  plugins: [typescript()]
+  plugins: [typescript({cacheRoot: `${require('temp-dir')}/.rpt2_cache`})]
 }


### PR DESCRIPTION

* tarball contains .rtp2_cache files
```bash
# view tarball url
npm view number-precision@1.5.1 dist.tarball --registry=https://registry.npmjs.org
```
* files maybe exceed file path limit in some case (makensis.exe)
eg: ".rpt2_cache\5a4fe61d3887fcee7b778318e00acf79ad3e67ec\code\cache\5b8f4d93341881a961ee5da85ea69fc87f3dfb8c"