### PR TITLE
refacotr: smaller package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "tsc -p tsconfig.test.json && nyc --reporter=lcov --reporter=text --reporter=json ava && rm -rf .nyc_output",
     "posttest": "codecov -f coverage/*.json -t 072762c4-c5bc-4393-bcd9-71eac9e7725b",
     "prepublish": "rm -rf build && tsc && npm run build",
-    "tslint": "tslint './src/**/*.?(ts|tsx)'"
+    "tslint": "tslint ./src/**/*.ts --fix"
   },
   "ava": {
     "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,10 +65,10 @@ function checkBoundary(num: number) {
 function createOperation(operation: (n1: NumberType, n2: NumberType) => number): (...nums: NumberType[]) => number {
   return (...nums: NumberType[]) => {
     let result = nums[0] as number;
-    const loop = nums.slice(1);
+    const others = nums.slice(1);
 
-    while (loop.length) {
-      result = operation(result, loop.shift()!);
+    for (let i = 0, len = others.length; i < len; ++i) {
+      result = operation(result, others[i]);
     }
 
     return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,29 @@
-type numType = number | string;
 /**
  * @desc 解决浮动运算问题，避免小数点后产生多位数和计算精度损失。
+ *
  * 问题示例：2.3 + 2.4 = 4.699999999999999，1.0 - 0.9 = 0.09999999999999998
  */
 
+type NumberType = number | string;
+
 /**
- * 把错误的数据转正
- * strip(0.09999999999999998)=0.1
+ * Correct the given number to specifying significant digits.
+ *
+ * @param num The input number
+ * @param precision An integer specifying the number of significant digits
+ *
+ * @example strip(0.09999999999999998) === 0.1 // true
  */
-function strip(num: numType, precision = 15): number {
+function strip(num: NumberType, precision = 15): number {
   return +parseFloat(Number(num).toPrecision(precision));
 }
 
 /**
- * Return digits length of a number
- * @param {*number} num Input number
+ * Return digits length of a number.
+ *
+ * @param num The input number
  */
-function digitLength(num: numType): number {
+function digitLength(num: NumberType): number {
   // Get digit length of e
   const eSplit = num.toString().split(/[eE]/);
   const len = (eSplit[0].split('.')[1] || '').length - +(eSplit[1] || 0);
@@ -24,10 +31,12 @@ function digitLength(num: numType): number {
 }
 
 /**
- * 把小数转成整数，支持科学计数法。如果是小数则放大成整数
- * @param {*number} num 输入数
+ * Convert the given number to integer, support scientific notation.
+ * The number will be scale up if it is decimal.
+ *
+ * @param num The input number
  */
-function float2Fixed(num: numType): number {
+function float2Fixed(num: NumberType): number {
   if (num.toString().indexOf('e') === -1) {
     return Number(num.toString().replace('.', ''));
   }
@@ -36,8 +45,9 @@ function float2Fixed(num: numType): number {
 }
 
 /**
- * 检测数字是否越界，如果越界给出提示
- * @param {*number} num 输入数
+ * Log a warning if the given number is out of bounds.
+ *
+ * @param num The input number
  */
 function checkBoundary(num: number) {
   if (_boundaryCheckingState) {
@@ -48,10 +58,12 @@ function checkBoundary(num: number) {
 }
 
 /**
- * 创建操作
+ * Create an operation to support rest params.
+ *
+ * @param operation The original operation
  */
-function createOperation(operation: (n1: numType, n2: numType) => number): (...nums: numType[]) => number {
-  return (...nums: numType[]) => {
+function createOperation(operation: (n1: NumberType, n2: NumberType) => number): (...nums: NumberType[]) => number {
+  return (...nums: NumberType[]) => {
     let result = nums[0] as number;
     const loop = nums.slice(1);
 
@@ -64,7 +76,9 @@ function createOperation(operation: (n1: numType, n2: numType) => number): (...n
 }
 
 /**
- * 精确乘法
+ * Accurate multiplication.
+ *
+ * @param nums The numbers to multiply
  */
 const times = createOperation((num1, num2) => {
   const num1Changed = float2Fixed(num1);
@@ -78,7 +92,9 @@ const times = createOperation((num1, num2) => {
 });
 
 /**
- * 精确加法
+ * Accurate addition.
+ *
+ * @param nums The numbers to add
  */
 const plus = createOperation((num1, num2) => {
   // 取最大的小数位
@@ -88,7 +104,9 @@ const plus = createOperation((num1, num2) => {
 });
 
 /**
- * 精确减法
+ * Accurate subtraction
+ *
+ * @param nums The numbers to subtract
  */
 const minus = createOperation((num1, num2) => {
   const baseNum = Math.pow(10, Math.max(digitLength(num1), digitLength(num2)));
@@ -96,34 +114,44 @@ const minus = createOperation((num1, num2) => {
 });
 
 /**
- * 精确除法
+ * Accurate division.
+ *
+ * @param nums The numbers to divide
  */
 const divide = createOperation((num1, num2) => {
   const num1Changed = float2Fixed(num1);
   const num2Changed = float2Fixed(num2);
+
   checkBoundary(num1Changed);
   checkBoundary(num2Changed);
+
   // fix: 类似 10 ** -4 为 0.00009999999999999999，strip 修正
   return times(num1Changed / num2Changed, strip(Math.pow(10, digitLength(num2) - digitLength(num1))));
 });
 
 /**
- * 四舍五入
+ * Accurate rounding method.
+ *
+ * @param num The number to round
+ * @param decimal An integer specifying the decimal digits
  */
-function round(num: numType, ratio: number): number {
-  const base = Math.pow(10, ratio);
+function round(num: NumberType, decimal: number): number {
+  const base = Math.pow(10, decimal);
   let result = divide(Math.round(Math.abs(times(num, base))), base);
+
   if (num < 0 && result !== 0) {
     result = times(result, -1);
   }
+
   return result;
 }
 
 let _boundaryCheckingState = true;
 
 /**
- * 是否进行边界检查，默认开启
- * @param flag 标记开关，true 为开启，false 为关闭，默认为 true
+ * Whether to check the bounds of number, default is enabled.
+ *
+ * @param flag The value to indicate whether is enabled
  */
 function enableBoundaryChecking(flag = true) {
   _boundaryCheckingState = flag;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,28 +48,25 @@ function checkBoundary(num: number) {
 }
 
 /**
- * 迭代操作
+ * 创建操作
  */
-function iteratorOperation(arr: numType[], operation: (...args: numType[]) => number): number {
-  const [num1, num2, ...others] = arr;
-  let res = operation(num1, num2);
+function createOperation(operation: (n1: numType, n2: numType) => number): (...nums: numType[]) => number {
+  return (...nums: numType[]) => {
+    let result = nums[0] as number;
+    const loop = nums.slice(1);
 
-  others.forEach((num) => {
-    res = operation(res, num);
-  });
+    while (loop.length) {
+      result = operation(result, loop.shift()!);
+    }
 
-  return res;
+    return result;
+  };
 }
 
 /**
  * 精确乘法
  */
-function times(...nums: numType[]): number {
-  if (nums.length > 2) {
-    return iteratorOperation(nums, times);
-  }
-
-  const [num1, num2] = nums;
+const times = createOperation((num1, num2) => {
   const num1Changed = float2Fixed(num1);
   const num2Changed = float2Fixed(num2);
   const baseNum = digitLength(num1) + digitLength(num2);
@@ -78,52 +75,37 @@ function times(...nums: numType[]): number {
   checkBoundary(leftValue);
 
   return leftValue / Math.pow(10, baseNum);
-}
+});
 
 /**
  * 精确加法
  */
-function plus(...nums: numType[]): number {
-  if (nums.length > 2) {
-    return iteratorOperation(nums, plus);
-  }
-
-  const [num1, num2] = nums;
+const plus = createOperation((num1, num2) => {
   // 取最大的小数位
   const baseNum = Math.pow(10, Math.max(digitLength(num1), digitLength(num2)));
   // 把小数都转为整数然后再计算
   return (times(num1, baseNum) + times(num2, baseNum)) / baseNum;
-}
+});
 
 /**
  * 精确减法
  */
-function minus(...nums: numType[]): number {
-  if (nums.length > 2) {
-    return iteratorOperation(nums, minus);
-  }
-
-  const [num1, num2] = nums;
+const minus = createOperation((num1, num2) => {
   const baseNum = Math.pow(10, Math.max(digitLength(num1), digitLength(num2)));
   return (times(num1, baseNum) - times(num2, baseNum)) / baseNum;
-}
+});
 
 /**
  * 精确除法
  */
-function divide(...nums: numType[]): number {
-  if (nums.length > 2) {
-    return iteratorOperation(nums, divide);
-  }
-
-  const [num1, num2] = nums;
+const divide = createOperation((num1, num2) => {
   const num1Changed = float2Fixed(num1);
   const num2Changed = float2Fixed(num2);
   checkBoundary(num1Changed);
   checkBoundary(num2Changed);
   // fix: 类似 10 ** -4 为 0.00009999999999999999，strip 修正
   return times(num1Changed / num2Changed, strip(Math.pow(10, digitLength(num2) - digitLength(num1))));
-}
+});
 
 /**
  * 四舍五入
@@ -138,6 +120,7 @@ function round(num: numType, ratio: number): number {
 }
 
 let _boundaryCheckingState = true;
+
 /**
  * 是否进行边界检查，默认开启
  * @param flag 标记开关，true 为开启，false 为关闭，默认为 true
@@ -145,7 +128,9 @@ let _boundaryCheckingState = true;
 function enableBoundaryChecking(flag = true) {
   _boundaryCheckingState = flag;
 }
+
 export { strip, plus, minus, times, divide, round, digitLength, float2Fixed, enableBoundaryChecking };
+
 export default {
   strip,
   plus,

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ const plus = createOperation((num1, num2) => {
 });
 
 /**
- * Accurate subtraction
+ * Accurate subtraction.
  *
  * @param nums The numbers to subtract
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,13 +64,8 @@ function checkBoundary(num: number) {
  */
 function createOperation(operation: (n1: NumberType, n2: NumberType) => number): (...nums: NumberType[]) => number {
   return (...nums: NumberType[]) => {
-    let result = nums[0] as number;
-
-    for (let i = 1, len = nums.length; i < len; ++i) {
-      result = operation(result, nums[i]);
-    }
-
-    return result;
+    const [first, ...others] = nums;
+    return others.reduce((prev, next) => operation(prev, next), first) as number;
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,10 +65,9 @@ function checkBoundary(num: number) {
 function createOperation(operation: (n1: NumberType, n2: NumberType) => number): (...nums: NumberType[]) => number {
   return (...nums: NumberType[]) => {
     let result = nums[0] as number;
-    const others = nums.slice(1);
 
-    for (let i = 0, len = others.length; i < len; ++i) {
-      result = operation(result, others[i]);
+    for (let i = 1, len = nums.length; i < len; ++i) {
+      result = operation(result, nums[i]);
     }
 
     return result;


### PR DESCRIPTION
在这个 PR 中我做了一些改进，以及一些自作主张的调整。

- 改变了运算方法的创建方式，采用了一个构造方法来创建运算方法，并在这个过程中使用循环取代了递归
- 将所有的方法的注释改为了英语，并补全了参数说明

首先关于第一点，我实施它是因为可以使得压缩 gzip 后包变得更小了：

之前：![before](https://user-images.githubusercontent.com/40221744/177272825-9e1e4b12-3e4b-4045-b678-e4f55462fdae.png)

之后：![after](https://user-images.githubusercontent.com/40221744/177272836-10ae0107-40a9-44ce-8d48-5675859453a8.png)

同时在效率上能够有微弱的提升：

```js
function test() {
  let times = 0
  for (let i = 0; i < 10; ++i) {
    let start = Date.now()
    NP.plus(...new Array(120000).fill(1))
    times += Date.now() - start
  }
  console.log(times / 10)
}
```

在 Chrome 下运行数次，递归方案平均时长约在 242ms，循环方案时长约在 235ms，不过这个性能差异在正常的使用中我觉得几乎没影响。

第二点是我自作主张的调整，我认为全面的参数说明和英语能够更广泛的适应更多用户，如果你不喜欢这样的调整，我可以撤回。